### PR TITLE
Updated appId generation logic

### DIFF
--- a/model/install_json_model.py
+++ b/model/install_json_model.py
@@ -503,7 +503,7 @@ def get_commit_hash() -> str | None:
 
 def gen_app_id() -> UUID5:
     """Return a generate id for the current App."""
-    return uuid.uuid5(uuid.NAMESPACE_X500, os.path.basename(os.getcwd()).lower())
+    return uuid.uuid4()
 
 
 class InstallJsonCommonModel(BaseModel):


### PR DESCRIPTION
APP-4439 - [PACKAGE] Changed appId creation logic to used UUID4 instead of UUID5 for App Builder