### PR TITLE
Relax Pydantic Version Requirements

### DIFF
--- a/model/app_spec_yml_model.py
+++ b/model/app_spec_yml_model.py
@@ -6,7 +6,7 @@ import re
 from copy import deepcopy
 
 # third-party
-from pydantic import BaseModel, Field, root_validator, validator
+from pydantic.v1 import BaseModel, Field, root_validator, validator
 from semantic_version import Version
 
 from .install_json_model import (

--- a/model/install_json_model.py
+++ b/model/install_json_model.py
@@ -11,8 +11,8 @@ from enum import Enum
 from importlib.metadata import version as get_version
 
 # third-party
-from pydantic import BaseModel, Field, validator
-from pydantic.types import UUID4, UUID5, constr
+from pydantic.v1 import BaseModel, Field, validator
+from pydantic.v1.types import UUID4, UUID5, constr
 from semantic_version import Version
 
 __all__ = ['InstallJsonModel']

--- a/model/job_json_model.py
+++ b/model/job_json_model.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-self-argument
 
 # third-party
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 from semantic_version import Version
 
 __all__ = ['JobJsonModel']

--- a/model/layout_json_model.py
+++ b/model/layout_json_model.py
@@ -5,8 +5,8 @@
 from collections import OrderedDict
 
 # third-party
-from pydantic import BaseModel, Field
-from pydantic.types import constr
+from pydantic.v1 import BaseModel, Field
+from pydantic.v1.types import constr
 
 from ....pleb.none_model import NoneModel
 

--- a/model/tcex_json_model.py
+++ b/model/tcex_json_model.py
@@ -4,7 +4,7 @@
 from pathlib import PosixPath
 
 # third-party
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 __all__ = ['TcexJsonModel']
 


### PR DESCRIPTION
Pydantic v2 has been around for nearly 2 years, and as such many things use the new version. `tcex` and the associated repositories related to it all have a strict `<2.0.0` requirement on Pydantic, which is problematic when trying to utilize these libraries in a larger application or ecosystem which uses a newer version of Pydantic.

This PR and a collection of others I am in the process of making together aim to relax the version requirements for Pydantic by utilizing the `pydantic.v1` namespace introduced in `v1.10.17`. This `pyandic.v1` namespace allows users to utilize Pydantic as it was in v1 even when v2 is installed. It is explicitly listed as an option in the official [Migration Guide](https://docs.pydantic.dev/latest/migration/#using-pydantic-v1-features-in-a-v1v2-environment).

I plan to place this same PR description across all repositories which I found that needed updating, so here's some overarching information about this process as I have been able to understand it:

1. There are three "primary" projects which define Python packages: `tcex`, `tcex-cli`, and `tcex-app-testing`.
2. The primary projects need their `pyproject.toml` updated to relax the requirements to `>=1.10.17,<3.0.0`.
3. Secondary projects are used as submodules within the primary projects. The submodule projects that have references to pydantic are (as far as I could find): `tcex-app-config`, `tcex-app-playbook`, `tcex-util`.
4. All projects (primary and secondary) need all references to importing `pydantic` updated to reference `pydantic.v1`.

This is all relatively straightforward. In the forks I have made, I've run the following straightforward one-liner to replace all `from pydantic...` lines appropriately:

```sh
find . -name '*.py' | while read filepath; do
  sed 's/^from pydantic/from pydantic.v1/g' -i "$filepath"
done
```

For repositories with submodules (the primary repositories mentioned above), I filtered out the submodule paths before making this replacement. After the secondary repositories are merged, the primary repository submodules will also need to be updated to account for these changes in the primary repositories as well.

I will be the first to admit that I am not the best person to test all of this as I'm not intimately familiar with `tcex` or all the in's and out's of your application(s). But I am familiar with Pydantic, and this version conflict is a bump in the road for me, so I'm happy to work through troubleshooting. I'm happy to discuss options and work with the team, but given that this was just a bunch of find-and-replace followed by careful coordination of submodules, I figured I'd at least get the ball rolling.

Once all six of the PRs are open, I'll go back through and make a comment on each to reference the others so they can be properly tracked/linked.